### PR TITLE
[#171734130] Allow zen_ex to support multiple configs, and support the user search endpoint

### DIFF
--- a/lib/zen_ex/core/models/user.ex
+++ b/lib/zen_ex/core/models/user.ex
@@ -156,4 +156,28 @@ defmodule ZenEx.Model.User do
   def destroy_many(ids) when is_list(ids) do
     HTTPClient.delete("/api/v2/users/destroy_many.json?ids=#{Enum.join(ids, ",")}", job_status: JobStatus)
   end
+
+  @doc """
+  Search for users specified by query.
+
+  ## Examples
+
+      iex> ZenEx.Model.User.search(%{email: "first.last@domain.com"})
+      %ZenEx.Collection{}
+
+      iex> ZenEx.Model.User.search("David"})
+      %ZenEx.Collection{}
+
+  """
+  @spec search(map()) :: %ZenEx.Collection{} | {:error, String.t()}
+  def search(opts) when is_map(opts) do
+    query = Map.keys(opts) |> Enum.map(fn key -> "#{key}:#{opts[key]}" end) |> Enum.join(" ")
+    search(query)
+  end
+
+  @spec search(String.t()) :: %ZenEx.Collection{} | {:error, String.t()}
+  def search(query) do
+    "/api/v2/users/search.json?query=#{query}"
+    |> HTTPClient.get(users: [User])
+  end
 end

--- a/lib/zen_ex/http_client.ex
+++ b/lib/zen_ex/http_client.ex
@@ -37,11 +37,11 @@ defmodule ZenEx.HTTPClient do
   end
 
   def build_url(endpoint) do
-    "https://#{Application.get_env(:zen_ex, :subdomain)}.zendesk.com#{endpoint}"
+    "https://#{get_env(:subdomain)}.zendesk.com#{endpoint}"
   end
 
   def basic_auth do
-    {"#{Application.get_env(:zen_ex, :user)}/token", "#{Application.get_env(:zen_ex, :api_token)}"}
+    {"#{get_env(:user)}/token", "#{get_env(:api_token)}"}
   end
 
   def _build_entity(%HTTPotion.Response{} = res, [{key, [module]}]) do
@@ -57,5 +57,10 @@ defmodule ZenEx.HTTPClient do
   end
   def _build_entity(%HTTPotion.ErrorResponse{message: error}, _) do
     {:error, error}
+  end
+
+  defp get_env(key) do
+    config_module = Process.get(:zendesk_config_module)
+    if config_module, do: Application.get_env(:zen_ex, config_module) |> Keyword.get(key), else: Application.get_env(:zen_ex, key)
   end
 end

--- a/lib/zen_ex/http_client.ex
+++ b/lib/zen_ex/http_client.ex
@@ -60,7 +60,9 @@ defmodule ZenEx.HTTPClient do
   end
 
   defp get_env(key) do
-    config_module = Process.get(:zendesk_config_module)
-    if config_module, do: Application.get_env(:zen_ex, config_module) |> Keyword.get(key), else: Application.get_env(:zen_ex, key)
-  end
+   case Process.get(:zendesk_config_module) do
+     nil -> Application.get_env(:zen_ex, key)
+     config_module -> Application.get_env(:zen_ex, config_module)[key]
+   end
+ end
 end


### PR DESCRIPTION
<!-- Add a link for pivotal tracker -->
[PT-#171734130](https://www.pivotaltracker.com/story/show/171734130)

## Description
This PR allows the `zen_ex` library to support multiple Zendesk configs within a single app using it. We require this as our privacy automation initiative needs to be able to talk to both the CS Zendesk as well as Zendesk Merch to perform privacy request fulfillments. 

In order to use the multiple configs, you want to have a set of core zen_ex config settings, as well as whatever auxiliary config settings you want to support keyed by a class name. For example: 

```
config :zen_ex,
  subdomain: System.get_env("USER_ZENDESK_SUBDOMAIN"),
  user: System.get_env("USER_ZENDESK_USER_EMAIL"),
  api_token: System.get_env("USER_ZENDESK_API_TOKEN")

config :zen_ex, User.ZendeskMerch,
  subdomain: System.get_env("USER_ZENDESK_MERCH_SUBDOMAIN"),
  user: System.get_env("USER_ZENDESK_MERCH_USER_EMAIL"),
  api_token: System.get_env("USER_ZENDESK_MERCH_API_TOKEN")
```

Then, anywhere you want to use the config settings for the alternate Zendesk instance, you put a `:zendesk_config_module` key onto the `Process` dictionary with the class name the settings are keyed against in your config, like so: 

```
Process.put(:zendesk_config_module, User.ZendeskMerch)
ZenEx.User.Model.search(%{email: "first.last@company.com"})
Process.put(:zendesk_config_module, nil)
```

It is good practice to clean up as soon as you are done using `ZenEx` and set the `Process` `:zendesk_config_module` dictionary key back to `nil`
